### PR TITLE
Updating API URL to the Foxbit's one

### DIFF
--- a/docs/classes/_foxbit_client_.foxbitclient.html
+++ b/docs/classes/_foxbit_client_.foxbitclient.html
@@ -519,7 +519,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> url: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;wss://apifoxbitprodlb.alphapoint.com/WSGateway/&quot;</span></h5>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> url: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;wss://api.foxbit.com.br/WSGateway/&quot;</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Observable</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/src/foxbit-client.ts
+++ b/src/foxbit-client.ts
@@ -234,11 +234,11 @@ export class FoxBitClient {
   /**
    * Connect to FoxBit websocket endpoint
    *
-   * @param {string} [url='wss://apifoxbitprodlb.alphapoint.com/WSGateway/']
+   * @param {string} [url='wss://api.foxbit.com.br/WSGateway/']
    * @returns {Observable<boolean>}
    * @memberof FoxBitClient
    */
-  public connect(url: string = 'wss://apifoxbitprodlb.alphapoint.com/WSGateway/'): Observable<boolean> {
+  public connect(url: string = 'wss://api.foxbit.com.br/WSGateway/'): Observable<boolean> {
     try {
       this.connectSubject = new Subject<boolean>();
       const logEnabled = process.env.LOG_ENABLED === 'true';


### PR DESCRIPTION
Just an update of our API URL, soon the older one will not be working anymore.

**New  WS API URL**: wss://api.foxbit.com.br/WSGateway/